### PR TITLE
Fix treatment of no-output ERB tags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Tests",
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/node_modules/.bin/mocha",
+            "args": [
+                "--colors"
+            ]
+
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     //////////////////////////////////////
     // Git
     //////////////////////////////////////
-    "git.inputValidation": "warn",
+    "git.inputValidation": true,
     "git.inputValidationSubjectLength": 50,
     "git.inputValidationLength": 72,
     "cSpell.words": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,30 @@
     "git.inputValidationLength": 72,
     "cSpell.words": [
         "lintable"
-    ]
+    ],
+    //////////////////////////////////////
+    // Editor
+    //////////////////////////////////////
+    "editor.indentSize": 2,
+    "editor.tabSize": 2,
+    "[html,js]": {
+        "editor.indentSize": 4,
+        "editor.tabSize": 4
+    },
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.renderFinalNewline": "on",
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100, // toggle via Alt + Z shortcut
+    "editor.mouseWheelZoom": true,
+    "editor.rulers": [
+        {
+            "column": 80, // soft limit
+            "color": "#e5e5e5"
+        },
+        {
+            "column": 100, // hard limit
+            "color": "#c9c9c9"
+        }
+    ],
 }

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -87,6 +87,10 @@ function replaceTextWithDummy(lintableTextArr, startIndex, length, dummy) {
 }
 
 function preprocessJs(text, filename) {
+  function wrapInEslintDisable(text) {
+    return `/* eslint-disable */${text}/* eslint-enable */`;
+  }
+
   function toDummyString(id, matchText) {
     if (matchText.startsWith("<%=")) {
       return wrapInEslintDisable(`{}/* eslint-plugin-erb ${HASH} ${id} */`);
@@ -101,10 +105,6 @@ function preprocessHtml(text, filename) {
     return `<!-- ${HASH} ${id} -->`;
   }
   return preprocess(text, filename, toDummyString);
-}
-
-function wrapInEslintDisable(text) {
-  return `/* eslint-disable */${text}/* eslint-enable */`;
 }
 
 module.exports = {

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -19,13 +19,12 @@ const HASH = "566513c5d83ac26e15414f2754"; // to avoid collisions with user code
  * location of messages in the postprocess step later.
  * @param {string} text text of the file
  * @param {string} filename filename of the file
- * @param {(id) => string} dummyString dummy string to replace ERB tags with
- *                                     (this is language-specific). Should be
- *                                     a function that takes an id and returns
- *                                     a UNIQUE dummy string.
+ * @param {(id) => string} toDummyString function that takes an id and the
+ * matched text and returns a dummy string to replace the matched text with.
+ * This dummy string must be unique.
  * @returns {Array<{ filename: string, text: string }>} source code blocks to lint
  */
-function preprocess(text, filename, dummyString) {
+function preprocess(text, filename, toDummyString) {
   let lintableTextArr = text.split("");
 
   let match;
@@ -47,7 +46,7 @@ function preprocess(text, filename, dummyString) {
     numAddLines += matchLines.length - 1;
 
     // Columns
-    const dummy = dummyString(matchedId);
+    const dummy = toDummyString(matchedId, matchText);
     const coordStartIndex = indexToColumn(text, startIndex);
     const endColumnAfter = coordStartIndex.column + dummy.length;
     const coordEndIndex = indexToColumn(text, endIndex);
@@ -88,17 +87,24 @@ function replaceTextWithDummy(lintableTextArr, startIndex, length, dummy) {
 }
 
 function preprocessJs(text, filename) {
-  function dummyString(id) {
-    return `/* eslint-disable */{}/* ${HASH} ${id} *//* eslint-enable */`;
+  function toDummyString(id, matchText) {
+    if (matchText.startsWith("<%=")) {
+      return wrapInEslintDisable(`{}/* eslint-plugin-erb ${HASH} ${id} */`);
+    }
+    return wrapInEslintDisable(`/* eslint-plugin-erb ${HASH} ${id} */`);
   }
-  return preprocess(text, filename, dummyString);
+  return preprocess(text, filename, toDummyString);
 }
 
 function preprocessHtml(text, filename) {
-  function dummyString(id) {
+  function toDummyString(id, _matchText) {
     return `<!-- ${HASH} ${id} -->`;
   }
-  return preprocess(text, filename, dummyString);
+  return preprocess(text, filename, toDummyString);
+}
+
+function wrapInEslintDisable(text) {
+  return `/* eslint-disable */${text}/* eslint-enable */`;
 }
 
 module.exports = {

--- a/tests/eslint.test.config.js
+++ b/tests/eslint.test.config.js
@@ -37,6 +37,10 @@ module.exports = [
       },
     },
     ignores: ["**/*.html**"],
+    linterOptions: {
+      // see https://github.com/Splines/eslint-plugin-erb/releases/tag/v2.0.1
+      reportUnusedDisableDirectives: "off",
+    },
   },
   {
     // HTML linting (aside from erb_lint)
@@ -77,6 +81,10 @@ module.exports = [
         disallowTabs: true,
         disallowInAssignment: true,
       }],
+    },
+    linterOptions: {
+      // see https://github.com/Splines/eslint-plugin-erb/releases/tag/v2.0.1
+      reportUnusedDisableDirectives: "off",
     },
   },
 ];

--- a/tests/eslint.test.config.js
+++ b/tests/eslint.test.config.js
@@ -82,9 +82,5 @@ module.exports = [
         disallowInAssignment: true,
       }],
     },
-    linterOptions: {
-      // see https://github.com/Splines/eslint-plugin-erb/releases/tag/v2.0.1
-      reportUnusedDisableDirectives: "off",
-    },
   },
 ];

--- a/tests/fixtures/multiple-erb-in-one-line.expected.js
+++ b/tests/fixtures/multiple-erb-in-one-line.expected.js
@@ -1,1 +1,1 @@
-console.log ("Hi "); <%# This is a comment %>console.log("whatever"); <% if true %> console.log("true"); <% end %>
+console.log ("Hi "); <%# This is a comment %>console.log("whatever"); <% if true %> console.log("true");<% end %>

--- a/tests/fixtures/multiple-erb-in-one-line.js
+++ b/tests/fixtures/multiple-erb-in-one-line.js
@@ -1,1 +1,1 @@
-console.log ("Hi ");<%# This is a comment %>console.log('whatever');<% if true %> console.log('true');<% end %>
+console.log ("Hi "); <%# This is a comment %>console.log('whatever'); <% if true %> console.log('true');<% end %>

--- a/tests/fixtures/no-output-erb-tag.expected.js
+++ b/tests/fixtures/no-output-erb-tag.expected.js
@@ -1,0 +1,6 @@
+OSM = {
+<% if something %>
+  MATOMO: <%= Settings.matomo.to_json %>,
+<% end %>
+  MAX_REQUEST_AREA: <%= Custom.to_yml %>
+};

--- a/tests/fixtures/no-output-erb-tag.js
+++ b/tests/fixtures/no-output-erb-tag.js
@@ -1,0 +1,6 @@
+OSM =  {
+<% if something %>
+   MATOMO : <%= Settings.matomo.to_json %>,
+<% end %>
+  MAX_REQUEST_AREA:  <%= Custom.to_yml %>
+}

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const assert = require("chai").assert;
+const expect = require("chai").expect;
 const { ESLint } = require("eslint");
 
 const eslint = new ESLint({
@@ -11,7 +11,7 @@ async function runTest(filename, expectedFilename) {
   const testCode = fs.readFileSync(filename, "utf-8");
   const result = await eslint.lintText(testCode, { filePath: filename });
   const expectedCode = fs.readFileSync(expectedFilename, "utf-8");
-  assert.strictEqual(result[0].output, expectedCode);
+  expect(result[0].output).to.equal(expectedCode);
 }
 
 describe("Integration tests (JS)", () => {
@@ -22,6 +22,7 @@ describe("Integration tests (JS)", () => {
     "multiple-erb-in-one-line",
     "one-liner",
     "multiple-properties",
+    "no-output-erb-tag",
   ];
   mapFiles.forEach((name) => {
     it(`performs linting as we expect it on ${name}.js`, async () => {


### PR DESCRIPTION
Fixes #15. We now use the replacement to `{}` only if the ERB tag starts with `<%=`. For all other tags (including `<%` and `<%#`), we replace them by a simple comment, without any actual remaining JS-syntax (i.e. no `{}`).

A respective test was added.